### PR TITLE
Fix exception when using multiple hubs

### DIFF
--- a/lib/hubs/hubFactory.js
+++ b/lib/hubs/hubFactory.js
@@ -66,8 +66,10 @@ module.exports = function(hubName,hubObject){
 		createClientResponse : function(req,cb){
 			assert(cb);
 			var hubCall = this.getHubCall(req);
-			if(!hubCall)
+			if(!hubCall) {
 				cb();
+				return;
+			}
 			this.functions[hubCall.Method].apply(this.functions,hubCall.Args);
 			var message = createClientMessage(this.name,this.functions.clients);
 			cb(null,message.callData,message.user);


### PR DESCRIPTION
If you have multiple hubs with different methods on the hubs, an
exception would be thrown because a method could not be looked up. The
error is that instead of exiting the function to try the next hub, it would
try to execute the function on the hub that didn't have the method.
