### PR TITLE
fix(polling): do not poll against closed connections

### DIFF
--- a/lib/signalRJS.js
+++ b/lib/signalRJS.js
@@ -88,9 +88,11 @@ SignalRJS.prototype.poll = function(req,res){
 	this._connectionManager.updateConnection(req.signalrjs.token,res);
 	setTimeout(function(){
 		var connection = self._connectionManager.getByToken(token);
+		if (!connection) return;
+
 		var transport = self._transports[connection.type];
-		if(transport)
-			transport.send(connection.connection,[]);
+		if(!transport) return;
+		transport.send(connection.connection,[]);
 	},30000);
 };
 


### PR DESCRIPTION
The token's connection may have been closed in the interval between when `setTimeout` was created and when it fires. Within the handler, ensure that the connection still exists.

Fixes #3 