### PR TITLE
fix(response): allow server methods to not have a response

### DIFF
--- a/lib/hubs/hubFactory.js
+++ b/lib/hubs/hubFactory.js
@@ -68,8 +68,12 @@ module.exports = function(hubName,hubObject){
 			var hubCall = this.getHubCall(req);
 			if(!hubCall)
 				cb();
+				return;
 			this.functions[hubCall.Method].apply(this.functions,hubCall.Args);
 			var message = createClientMessage(this.name,this.functions.clients);
+			if(!message)
+				cb();
+				return;
 			cb(null,message.callData,message.user);
 		}
 	};

--- a/lib/hubs/hubFactory.js
+++ b/lib/hubs/hubFactory.js
@@ -66,14 +66,16 @@ module.exports = function(hubName,hubObject){
 		createClientResponse : function(req,cb){
 			assert(cb);
 			var hubCall = this.getHubCall(req);
-			if(!hubCall)
+			if(!hubCall){
 				cb();
-				return;
+        return;
+      }
 			this.functions[hubCall.Method].apply(this.functions,hubCall.Args);
 			var message = createClientMessage(this.name,this.functions.clients);
-			if(!message)
+			if(!message){
 				cb();
-				return;
+        return;
+      }
 			cb(null,message.callData,message.user);
 		}
 	};

--- a/lib/signalRJS.js
+++ b/lib/signalRJS.js
@@ -152,6 +152,8 @@ SignalRJS.prototype.hubRoute = function(req,res){
 	hubs.parseMessage(req,function(responseMsg,toUser){
 		res.writeHead(200, {"Content-Type": "application/json"});
 		res.end();
+		if(!responseMsg)
+			return;
 		if(toUser)
 			return self.sendToUser(toUser,responseMsg);
 		self.broadcast(responseMsg);


### PR DESCRIPTION
Server methods should not be required to invoke a client method in response. This change updates response messages to handle empty `callData`.

Fixes #5